### PR TITLE
Bug: add `new` keyword to initialize Repo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const config = {
 }
 
 const PORT = 3030
-const serverRepo = Repo(config)
+const serverRepo = new Repo(config)
 const app = express()
 app.use(express.static("public"))
 


### PR DESCRIPTION
I think the new keyword is missing in this example code. Feel free to merge or decline.